### PR TITLE
Update image tests to only check pip major version

### DIFF
--- a/dockerfile_full/image_tests/tests/test_python.py
+++ b/dockerfile_full/image_tests/tests/test_python.py
@@ -9,10 +9,8 @@ class TestPython(unittest.TestCase):
         self.assertGreaterEqual(sys.version_info.minor, 8)
 
     def test_pip_version(self):
-        # Checks that pip version is at least 22.0.2
+        # Checks that pip version is at least 22.0
         import pip
         pip_version = pip.__version__.split('.')
 
         self.assertGreaterEqual(int(pip_version[0]), 22)
-        self.assertGreaterEqual(int(pip_version[1]), 0)
-        self.assertGreaterEqual(int(pip_version[2]), 2)


### PR DESCRIPTION
## Major Changes and Improvements
  * N/A

## Bug Fixes
  * Modified "full" image tests so that only the major version of pip is compared, as sometimes pip is released with only a major and minor version, so checking for a version format X.X.X can lead to errors

## Minor Updates
  * N/A

## Tests and Validation
  * Verified that updated test for expected version of pip was successful

## Issues Closed
  * N/A