### PR TITLE
Change sudo configuration for startup script

### DIFF
--- a/dockerfile_base/Dockerfile
+++ b/dockerfile_base/Dockerfile
@@ -56,7 +56,8 @@ RUN useradd --create-home --uid=${UID} ${USERNAME} -p "$(openssl passwd -1 ${PAS
     && usermod -a -G sudo ${USERNAME}
 
 # Configure user permissions for startup script
-RUN printf "\n${USERNAME} ALL=(root:root) NOPASSWD: /etc/startup.sh\n" >> /etc/sudoers \
+RUN printf "${USERNAME} ALL=(root:root) NOPASSWD: /etc/startup.sh\n" >> /etc/sudoers.d/startup \
+    && chmod 0440 /etc/sudoers.d/startup \
     && visudo -c
 
 # Set standard user as default

--- a/dockerfile_full/Dockerfile
+++ b/dockerfile_full/Dockerfile
@@ -62,7 +62,8 @@ RUN useradd --create-home --uid=${UID} ${USERNAME} -p "$(openssl passwd -1 ${PAS
     && usermod -a -G sudo ${USERNAME}
 
 # Configure user permissions for startup script
-RUN printf "\n${USERNAME} ALL=(root:root) NOPASSWD: /etc/startup.sh\n" >> /etc/sudoers \
+RUN printf "${USERNAME} ALL=(root:root) NOPASSWD: /etc/startup.sh\n" >> /etc/sudoers.d/startup \
+    && chmod 0440 /etc/sudoers.d/startup \
     && visudo -c
 
 # Set standard user as default


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Modified sudo configuration (which allows standard user to run startup script without entering a password) by adding custom configuration command to a file in `/etc/sudoers.d/` rather than directly appending it to the `/etc/sudoers` file

## Tests and Validation
- Built images locally and verified that standard user can run `/etc/startup.sh` without entering password