### PR TITLE
Fix incorrect node memory calculation that led to drained state

### DIFF
--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Image name to use when building test image
     required: false
     default: testimage
+  timeout_duration:
+    description: Duration after which to kill test script if it has not already exited
+    required: false
+    default: 120s
 
 runs:
   using: composite
@@ -37,7 +41,9 @@ runs:
         if [ "${{ inputs.user }}" == "standard" ]; then sudo_cmd="sudo"; fi
         test_script="/host/${{ inputs.docker_build_context }}/image_tests/run_tests.sh"
         docker run --rm -v "$GITHUB_WORKSPACE":/host "${{ inputs.test_img_name }}:${{ inputs.user }}" \
-          /bin/bash -c "${sudo_cmd} /etc/startup.sh && bash '${test_script}' '${{ inputs.user }}'"
+          /bin/bash -c "${sudo_cmd} /etc/startup.sh \
+            && timeout --kill-after=${{ inputs.timeout_duration }} ${{ inputs.timeout_duration }} \
+               bash '${test_script}' '${{ inputs.user }}'"
 
     - name: Remove Test Image
       if: ${{ always() }}

--- a/dockerfile_base/image_tests/run_tests.sh
+++ b/dockerfile_base/image_tests/run_tests.sh
@@ -27,6 +27,9 @@ check_pkg_exists() {
     fi
 }
 
+# Give Slurm enought time to initialize
+sleep 2
+
 
 ## TESTS ---------------------------------------------------------------------
 # Check operating system version

--- a/dockerfile_base/startup.sh
+++ b/dockerfile_base/startup.sh
@@ -12,7 +12,7 @@ fi
 ${sudo_cmd} bash <<SCRIPT
 sed -i "s/<<HOSTNAME>>/$(hostname)/" /etc/slurm/slurm.conf
 sed -i "s/<<CPU>>/$(nproc)/" /etc/slurm/slurm.conf
-sed -i "s/<<MEMORY>>/$(awk '/MemTotal/ { printf "%.0f \n", $2/1024 }' /proc/meminfo)/" /etc/slurm/slurm.conf
+sed -i "s/<<MEMORY>>/$(if [[ "$(slurmd -C)" =~ RealMemory=([0-9]+) ]]; then echo "${BASH_REMATCH[1]}"; else exit 100; fi)/" /etc/slurm/slurm.conf
 service munge start
 service slurmd start
 service slurmctld start


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed bug in which `RealMemory` set in `slurm.conf` was sometimes rounded up incorrectly, leading to the node in a "drained" state.  Rather than calculating the available memory based on `/proc/meminfo`, the value was obtained from `slurmd -C`

## Minor Updates
- Added timeout period to tests to kill tests (and indicate failure) after 2 minutes to avoid the workflow becoming unresponsive

## Tests and Validation
- Issue was reproduced in GitHub Actions (example run [here](https://github.com/nathan-hess/docker-slurm/actions/runs/4954431095)), and it was verified that after the changes, the issue was no longer observed (example run [here](https://github.com/nathan-hess/docker-slurm/actions/runs/4963175666))

## Issues Closed
- Closes #18

## Notes and References
- https://stackoverflow.com/questions/35919103/how-do-i-use-a-regex-in-a-shell-script
- https://stackoverflow.com/questions/28256178/how-can-i-match-spaces-with-a-regexp-in-bash