### PR TITLE
Fix bug in image publish workflow in which required dependency image was not generated

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -60,6 +60,16 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Build Image - base/root (full image dependency)
+        if: ${{ github.event_name == 'release' }}
+        uses: './.github/workflows/composite-actions/docker-build-push'
+        with:
+          user: root
+          context: dockerfile_base/
+          load: 'true'
+          push: 'false'
+          tags: ${{ env.DOCKER_HUB_REPO }}:${{ env.TAG_BASE_ROOT }}
+
       - name: Publish Docker Image - full - standard
         if: ${{ always() }}
         uses: './.github/workflows/composite-actions/test-publish'


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed mistake when publishing images tagged with release version.  During the workflow, the `base-root` image must be generated (without the release tag) as a dependency for the `full` and `full-root` images, but this was accidentally skipped