### PR TITLE
Set locale when building image

### DIFF
--- a/dockerfile_base/Dockerfile
+++ b/dockerfile_base/Dockerfile
@@ -23,6 +23,11 @@ RUN ln -sn /usr/share/zoneinfo/${TIMEZONE} /etc/localtime \
     && echo ${TIMEZONE} > /etc/timezone \
     && apt -y install tzdata
 
+# Set locale
+RUN apt -y install locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8 LC_MESSAGES=POSIX
+
 # Install system packages
 RUN DEBIAN_FRONTEND=noninteractive \
     apt -y install munge \


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Updated Dockerfile to explicitly set locale when building images.  If the locale is not set, this can lead to errors when performing tasks such as building documentation with Sphinx in VS Code since VS Code automatically changes some language-related environment settings

## Notes and References
- https://help.ubuntu.com/community/Locale